### PR TITLE
Changed group to com.netifi.proteus.brokerServices

### DIFF
--- a/bin/proteus-info.js
+++ b/bin/proteus-info.js
@@ -53,7 +53,7 @@ const proteus = proteus_js_client.Proteus.create({
   },
 });
 
-const rSocket = proteus.group('com.netifi.proteus.admin.brokerServices');
+const rSocket = proteus.group('com.netifi.proteus.brokerServices');
 const brokerInfo = new proteus_js_client.BrokerInfoServiceClient(rSocket);
 
 const spinner = ora();
@@ -90,6 +90,7 @@ program
   .description('list brokers')
   .action(() => {
     program.promise = new Promise((resolve, reject) => {
+      console.log('fetching brokers...');
       brokerInfo
         .brokers(new empty_pb.Empty(), Buffer.alloc(0))
         .subscribe(flowableSubscriber(resolve, reject));
@@ -283,7 +284,10 @@ if (program.promise) {
   program.promise
     .then(
       () => spinner.succeed(),
-      error => spinner.fail(error.message))
+      error => {
+        spinner.fail();
+        console.error(error);
+      })
     .then(() => {
       proteus.close();
       process.exit(1);

--- a/bin/proteus-info.js
+++ b/bin/proteus-info.js
@@ -90,7 +90,6 @@ program
   .description('list brokers')
   .action(() => {
     program.promise = new Promise((resolve, reject) => {
-      console.log('fetching brokers...');
       brokerInfo
         .brokers(new empty_pb.Empty(), Buffer.alloc(0))
         .subscribe(flowableSubscriber(resolve, reject));

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "proteus-cli",
-  "version": "0.0.6",
+  "version": "0.0.7",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {


### PR DESCRIPTION
I changed the broker info group because I wasn't receiving results from local brokers. I also moved thrown errors outside of the spinner because they were getting dropped sometimes.